### PR TITLE
chore: remove ggbeeswarm

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Type: Package
 Package: NACHO
 Title: NanoString Quality Control Dashboard
-Version: 2.0.1
+Version: 2.0.2
 Authors@R: 
     c(person(given = "Mickaël",
              family = "Canouil",
              role = c("aut", "cre"),
-             email = "mickael@canouil.dev",
+             email = "pro@mickael.canouil.dev",
              comment = c(ORCID = "0000-0002-3396-4549")),
       person(given = "Roderick",
              family = "Slieker",
@@ -39,7 +39,6 @@ Imports:
     utils,
     data.table,
     ggplot2 (>= 3.3.0),
-    ggbeeswarm (>= 0.6.0),
     ggforce (>= 0.3.1),
     ggrepel (>= 0.8.1),
     knitr (>= 1.25),
@@ -58,6 +57,6 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.2
 SystemRequirements: pandoc (>= 1.12.3), pandoc-citeproc
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# NACHO 2.0.2
+
+## Chores
+
+- In `DESCRIPTION`,
+  - chore: update email address.
+- chore: remove `ggbeeswarm`.
+
+**Full Changelog**: <https://github.com/mcanouil/NACHO/compare/v2.0.1...v2.0.2>
+
 # NACHO 2.0.1
 
 ## Chores

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -314,17 +314,18 @@ plot_metrics <- function(
     {
       if (show_outliers) {
         list(
-          ggbeeswarm::geom_quasirandom(
+          ggplot2::geom_point(
             data = ~ .x[!(is_outlier)],
-            size = size, width = 0.25, na.rm = TRUE, groupOnX = TRUE
+            size = size, width = 0.25, na.rm = TRUE,
+            position = ggplot2::position_jitter(width = 0.25)
           ),
-          ggbeeswarm::geom_quasirandom(
+          ggplot2::geom_point(
             data = ~ .x[(is_outlier)],
             size = size * outliers_factor,
             colour = "#b22222",
             width = 0.25,
             na.rm = TRUE,
-            groupOnX = TRUE
+            position = ggplot2::position_jitter(width = 0.25)
           ),
           if (!is.null(outliers_labels)) {
             ggrepel::geom_label_repel(
@@ -336,7 +337,10 @@ plot_metrics <- function(
           }
         )
       } else {
-        ggbeeswarm::geom_quasirandom(size = size, width = 0.25, na.rm = TRUE, groupOnX = TRUE)
+        ggplot2::geom_point(
+          size = size, width = 0.25, na.rm = TRUE,
+          position = ggplot2::position_jitter(width = 0.25)
+        )
       }
     } +
     ggplot2::labs(
@@ -443,17 +447,18 @@ plot_cg <- function(
     {
       if (show_outliers) {
         list(
-          ggbeeswarm::geom_quasirandom(
+          ggplot2::geom_point(
             data = ~ .x[!(is_outlier)],
-            size = size, width = 0.25, na.rm = TRUE, groupOnX = TRUE
+            size = size, width = 0.25, na.rm = TRUE,
+            position = ggplot2::position_jitter(width = 0.25)
           ),
-          ggbeeswarm::geom_quasirandom(
+          ggplot2::geom_point(
             data = ~ .x[(is_outlier)],
             size = size * outliers_factor,
             colour = "#b22222",
             width = 0.25,
             na.rm = TRUE,
-            groupOnX = TRUE
+            position = ggplot2::position_jitter(width = 0.25)
           ),
           if (!is.null(outliers_labels)) {
             ggrepel::geom_label_repel(
@@ -465,7 +470,10 @@ plot_cg <- function(
           }
         )
       } else {
-        ggbeeswarm::geom_quasirandom(size = size, width = 0.25, na.rm = TRUE, groupOnX = TRUE)
+        ggplot2::geom_point(
+          size = size, width = 0.25, na.rm = TRUE,
+          position = ggplot2::position_jitter(width = 0.25)
+        )
       }
     } +
     ggplot2::scale_y_log10(

--- a/R/render.R
+++ b/R/render.R
@@ -14,7 +14,7 @@
 #'   If a path is provided with a filename in `output_file` the directory specified here will take precedence.
 #'   Please note that any directory path provided will create any necessary directories if they do not exist.
 #' @param size [[numeric]] A numeric controlling point size
-#'   ([`ggplot2::geom_point()`] or #' [`ggbeeswarm::geom_beeswarm()`])
+#'   ([`ggplot2::geom_point()`]
 #'   or line size ([`ggplot2::geom_line()`]).
 #' @param show_legend [[logical]] Boolean to indicate whether the plot legends should
 #'   be plotted (`TRUE`) or not (`FALSE`). Default is `TRUE`.

--- a/man/NACHO-package.Rd
+++ b/man/NACHO-package.Rd
@@ -18,7 +18,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Mickaël Canouil \email{mickael.canouil@cnrs.fr} (\href{https://orcid.org/0000-0002-3396-4549}{ORCID})
+\strong{Maintainer}: Mickaël Canouil \email{pro@mickael.canouil.dev} (\href{https://orcid.org/0000-0002-3396-4549}{ORCID})
 
 Authors:
 \itemize{

--- a/man/autoplot.nacho.Rd
+++ b/man/autoplot.nacho.Rd
@@ -44,7 +44,7 @@ The possible values are:
 or more generally in \code{nacho_object$nacho} to be used as grouping colour.}
 
 \item{size}{[\link{numeric}] A numeric controlling point size
-(\code{\link[ggplot2:geom_point]{ggplot2::geom_point()}} or #' \code{\link[ggbeeswarm:geom_beeswarm]{ggbeeswarm::geom_beeswarm()}})
+(\code{\link[ggplot2:geom_point]{ggplot2::geom_point()}}
 or line size (\code{\link[ggplot2:geom_path]{ggplot2::geom_line()}}).}
 
 \item{show_legend}{[\link{logical}] Boolean to indicate whether the plot legends should

--- a/man/print.nacho.Rd
+++ b/man/print.nacho.Rd
@@ -25,7 +25,7 @@
 or more generally in \code{nacho_object$nacho} to be used as grouping colour.}
 
 \item{size}{[\link{numeric}] A numeric controlling point size
-(\code{\link[ggplot2:geom_point]{ggplot2::geom_point()}} or #' \code{\link[ggbeeswarm:geom_beeswarm]{ggbeeswarm::geom_beeswarm()}})
+(\code{\link[ggplot2:geom_point]{ggplot2::geom_point()}}
 or line size (\code{\link[ggplot2:geom_path]{ggplot2::geom_line()}}).}
 
 \item{show_legend}{[\link{logical}] Boolean to indicate whether the plot legends should

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -33,7 +33,7 @@ If a path is provided with a filename in \code{output_file} the directory specif
 Please note that any directory path provided will create any necessary directories if they do not exist.}
 
 \item{size}{[\link{numeric}] A numeric controlling point size
-(\code{\link[ggplot2:geom_point]{ggplot2::geom_point()}} or #' \code{\link[ggbeeswarm:geom_beeswarm]{ggbeeswarm::geom_beeswarm()}})
+(\code{\link[ggplot2:geom_point]{ggplot2::geom_point()}}
 or line size (\code{\link[ggplot2:geom_path]{ggplot2::geom_line()}}).}
 
 \item{show_legend}{[\link{logical}] Boolean to indicate whether the plot legends should


### PR DESCRIPTION
> We have repeatedly asked for an update fixing the check problems
shown on
 <https://cran.r-project.org/web/checks/check_results_ggbeeswarm.html>
with no reply from the maintainer thus far.
> 
> Thus, package ggbeeswarm is now scheduled for archival on 2022-12-19,
and archiving this will necessitate also archiving its CRAN strong
reverse dependencies.

<https://github.com/eclarke/ggbeeswarm/issues/75>