### PR TITLE
fix: set `height` in `ggplot2::position_jitter()` to `0` to avoid vertical dispersion points

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: NACHO
 Title: NanoString Quality Control Dashboard
-Version: 2.0.4
+Version: 2.0.5
 Authors@R: 
     c(person(given = "Mickaël",
              family = "Canouil",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # NACHO 2.0.5
 
+## Fixes
+
+- In `R/autoplot.R`,
+  - fix: set `height` in `ggplot2::position_jitter()` to `0` to avoid vertical dispersion points. ([#45](https://github.com/mcanouil/NACHO/issues/45))
+
+**Full Changelog**: <https://github.com/mcanouil/NACHO/compare/v2.0.4...v2.0.5>
+
 # NACHO 2.0.4
 
 ## Fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# NACHO 2.0.5
+
 # NACHO 2.0.4
 
 ## Fixes

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -317,7 +317,7 @@ plot_metrics <- function(
           ggplot2::geom_point(
             data = ~ .x[!(is_outlier)],
             size = size, width = 0.25, na.rm = TRUE,
-            position = ggplot2::position_jitter(width = 0.25)
+            position = ggplot2::position_jitter(width = 0.25, height = 0)
           ),
           ggplot2::geom_point(
             data = ~ .x[(is_outlier)],
@@ -325,7 +325,7 @@ plot_metrics <- function(
             colour = "#b22222",
             width = 0.25,
             na.rm = TRUE,
-            position = ggplot2::position_jitter(width = 0.25)
+            position = ggplot2::position_jitter(width = 0.25, height = 0)
           ),
           if (!is.null(outliers_labels)) {
             ggrepel::geom_label_repel(
@@ -339,7 +339,7 @@ plot_metrics <- function(
       } else {
         ggplot2::geom_point(
           size = size, width = 0.25, na.rm = TRUE,
-          position = ggplot2::position_jitter(width = 0.25)
+          position = ggplot2::position_jitter(width = 0.25, height = 0)
         )
       }
     } +
@@ -450,7 +450,7 @@ plot_cg <- function(
           ggplot2::geom_point(
             data = ~ .x[!(is_outlier)],
             size = size, width = 0.25, na.rm = TRUE,
-            position = ggplot2::position_jitter(width = 0.25)
+            position = ggplot2::position_jitter(width = 0.25, height = 0)
           ),
           ggplot2::geom_point(
             data = ~ .x[(is_outlier)],
@@ -458,7 +458,7 @@ plot_cg <- function(
             colour = "#b22222",
             width = 0.25,
             na.rm = TRUE,
-            position = ggplot2::position_jitter(width = 0.25)
+            position = ggplot2::position_jitter(width = 0.25, height = 0)
           ),
           if (!is.null(outliers_labels)) {
             ggrepel::geom_label_repel(
@@ -472,7 +472,7 @@ plot_cg <- function(
       } else {
         ggplot2::geom_point(
           size = size, width = 0.25, na.rm = TRUE,
-          position = ggplot2::position_jitter(width = 0.25)
+          position = ggplot2::position_jitter(width = 0.25, height = 0)
         )
       }
     } +


### PR DESCRIPTION
Fixes #45